### PR TITLE
Revert "Full compatibility with the "ExistentialAny" upcoming feature"

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -3,12 +3,6 @@
 
 import PackageDescription
 
-let swiftSettings: [SwiftSetting] = [
-    // https://github.com/apple/swift-evolution/blob/main/proposals/0335-existential-any.md
-    // Require `any` for existential types.
-    .enableUpcomingFeature("ExistentialAny")
-]
-
 let package = Package(
     name: "swift-openapi-hummingbird",
     platforms: [
@@ -27,16 +21,14 @@ let package = Package(
             dependencies: [
                 .product(name: "Hummingbird", package: "hummingbird"),
                 .product(name: "OpenAPIRuntime", package: "swift-openapi-runtime"),
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
         .testTarget(
             name: "OpenAPIHummingbirdTests",
             dependencies: [
                 "OpenAPIHummingbird",
                 .product(name: "HummingbirdXCT", package: "hummingbird"),
-            ],
-            swiftSettings: swiftSettings
+            ]
         ),
     ]
 )


### PR DESCRIPTION
Sorry for the trouble, but in my defense, i didn't foresee this bug 😅
https://github.com/apple/swift-openapi-generator/issues/119

I guess after all the PR didn't do much anyway, so we can revert the PR at once.
I also dropped the PR for the `swift-openapi-vapor` repo. Tim was lucky enough to review the PR late enough so we were aware of the bug already 😅

I don't think the bug is a big deal or affects many users, but we can prevent it easily so why not.