### PR TITLE
Update for HB 2.0.0-alpha.2

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-runtime.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-alpha.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-alpha.2"),
     ],
     targets: [
         .target(

--- a/Sources/OpenAPIHummingbird/OpenAPITransport.swift
+++ b/Sources/OpenAPIHummingbird/OpenAPITransport.swift
@@ -49,9 +49,15 @@ extension HBRequest {
     /// Construct ``OpenAPIRuntime.Request`` from Hummingbird ``HBRequest``
     func makeOpenAPIRequest<Context: HBBaseRequestContext>(context: Context) throws -> (HTTPRequest, HTTPBody?) {
         let request = self.head
+        // extract length from content-length header
+        let length = if let contentLengthHeader = self.headers[.contentLength], let contentLength = Int(contentLengthHeader) {
+            HTTPBody.Length.known(numericCast(contentLength))
+        } else {
+            HTTPBody.Length.unknown
+        }
         let body = HTTPBody(
             self.body.map { [UInt8](buffer: $0) },
-            length: .unknown,
+            length: length,
             iterationBehavior: .single
         )
         return (request, body)
@@ -74,7 +80,15 @@ extension HBResponse {
         let responseBody: HBResponseBody
         if let body = body {
             let bufferSequence = body.map { ByteBuffer(bytes: $0)}
-            responseBody = .init(asyncSequence: bufferSequence)
+            if case .known(let length) = body.length {
+                responseBody = .init(contentLength: numericCast(length)) { writer in
+                    for try await buffer in bufferSequence {
+                        try await writer.write(buffer)
+                    }
+                }
+            } else {
+                responseBody = .init(asyncSequence: bufferSequence)
+            }
         } else {
             responseBody = .init(byteBuffer: ByteBuffer())
         }

--- a/Sources/OpenAPIHummingbird/OpenAPITransport.swift
+++ b/Sources/OpenAPIHummingbird/OpenAPITransport.swift
@@ -49,17 +49,11 @@ extension HBRequest {
     /// Construct ``OpenAPIRuntime.Request`` from Hummingbird ``HBRequest``
     func makeOpenAPIRequest<Context: HBBaseRequestContext>(context: Context) throws -> (HTTPRequest, HTTPBody?) {
         let request = self.head
-        let body: HTTPBody?
-        switch self.body {
-        case .byteBuffer(let buffer):
-            body = HTTPBody([UInt8](buffer: buffer))
-        case .stream(let streamer):
-            body = .init(
-                streamer.map { [UInt8](buffer: $0) },
-                length: .unknown,
-                iterationBehavior: .single
-            )
-        }
+        let body = HTTPBody(
+            self.body.map { [UInt8](buffer: $0) },
+            length: .unknown,
+            iterationBehavior: .single
+        )
         return (request, body)
     }
 }

--- a/Tests/OpenAPIHummingbirdTests/OpenAPITransportTests.swift
+++ b/Tests/OpenAPIHummingbirdTests/OpenAPITransportTests.swift
@@ -79,6 +79,7 @@ final class HBOpenAPITransportTests: XCTestCase {
                 // Check the HBResponse (created from the Response) is what meets expectations.
                 XCTAssertEqual(hbResponse.status, .created)
                 XCTAssertEqual(hbResponse.headers[.xMumble], "mumble")
+                XCTAssertEqual(hbResponse.headers[.contentLength], "👋".utf8.count.description)
                 XCTAssertEqual(try String(buffer: XCTUnwrap(hbResponse.body)), "👋")
             }
         }


### PR DESCRIPTION
Code treats all requests as stream. It was already doing this, but still provided an option for extracting a ByteBuffer which never occurred. 