### PR TITLE
Extend RouterGroup, RouteCollection to support OpenAPI

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -13,7 +13,7 @@ let package = Package(
     ],
     dependencies: [
         .package(url: "https://github.com/apple/swift-openapi-runtime.git", from: "1.0.0"),
-        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-beta.1"),
+        .package(url: "https://github.com/hummingbird-project/hummingbird.git", from: "2.0.0-beta.6"),
     ],
     targets: [
         .target(

--- a/Sources/OpenAPIHummingbird/OpenAPITransport.swift
+++ b/Sources/OpenAPIHummingbird/OpenAPITransport.swift
@@ -18,7 +18,7 @@ import Hummingbird
 import NIOHTTP1
 import OpenAPIRuntime
 
-extension Router: ServerTransport {
+extension RouterMethods {
     /// Registers an HTTP operation handler at the provided path and method.
     /// - Parameters:
     ///   - handler: A handler to be invoked when an HTTP request is received.
@@ -100,3 +100,13 @@ extension Response {
         )
     }
 }
+
+#if hasFeature(RetroactiveAttribute)
+extension Router: @retroactive ServerTransport {}
+extension RouterGroup: @retroactive ServerTransport {}
+extension RouteCollection: @retroactive ServerTransport {}
+#else
+extension Router: ServerTransport {}
+extension RouterGroup: ServerTransport {}
+extension RouteCollection: ServerTransport {}
+#endif


### PR DESCRIPTION
This allows you to create a group, and apply middleware to just the OpenAPI endpoints, or pass a collection of endpoints around generated from an OpenAPI spec