### PR TITLE
Hummingbird 2's semantics changed, requiring body streams to finish the stream explicitly

### DIFF
--- a/Sources/OpenAPIHummingbird/OpenAPITransport.swift
+++ b/Sources/OpenAPIHummingbird/OpenAPITransport.swift
@@ -85,6 +85,7 @@ extension Response {
                     for try await buffer in bufferSequence {
                         try await writer.write(buffer)
                     }
+                    try await writer.finish(nil)
                 }
             } else {
                 responseBody = .init(asyncSequence: bufferSequence)


### PR DESCRIPTION
This currently causes crashes on reused connections